### PR TITLE
Enriched byte selection with shift button

### DIFF
--- a/hexalyzer/src/events.rs
+++ b/hexalyzer/src/events.rs
@@ -13,6 +13,7 @@ pub struct EventState {
     pub(crate) pointer_state: PointerState,
     pub(crate) escape_pressed: bool,
     pub(crate) enter_released: bool,
+    pub(crate) shift_down: bool,
     pub(crate) arrow_key_released: Option<egui::Key>,
 }
 
@@ -49,6 +50,7 @@ pub fn collect_ui_events(ui: &egui::Ui) -> EventState {
                 pointer_hover: i.pointer.hover_pos(),
                 pointer_down: i.pointer.primary_down(),
             },
+            shift_down: i.modifiers.shift,
             ..Default::default()
         };
 

--- a/hexalyzer/src/selection.rs
+++ b/hexalyzer/src/selection.rs
@@ -29,6 +29,14 @@ impl Selection {
         sel[1] = addr;
     }
 
+    /// Extend selection range to the provided address without clearing.
+    /// Used for Shift+Click range selection.
+    pub(crate) fn shift_update(&mut self, addr: usize) {
+        self.released = false;
+        let sel = self.range.get_or_insert([addr, addr]);
+        sel[1] = addr;
+    }
+
     /// Clear selection range
     pub(crate) const fn clear(&mut self) {
         self.range = None;

--- a/hexalyzer/src/ui_centralpanel.rs
+++ b/hexalyzer/src/ui_centralpanel.rs
@@ -54,6 +54,7 @@ impl HexSession {
         // let pointer_down = self.events.borrow().pointer_down;
         // let pointer_hover = self.events.borrow().pointer_hover;
         let pointer_state = self.events.borrow().pointer_state;
+        let shift_down = self.events.borrow().shift_down;
 
         // Detect released clicked
         if !pointer_state.pointer_down {
@@ -88,6 +89,7 @@ impl HexSession {
                 ui,
                 row,
                 pointer_state,
+                shift_down,
                 bytes_per_row,
                 display_start,
                 &bytes[i * bytes_per_row..(i + 1) * bytes_per_row],
@@ -124,6 +126,7 @@ impl HexSession {
         ui: &mut egui::Ui,
         row: usize,
         pointer_state: events::PointerState,
+        shift_down: bool,
         bytes_per_row: usize,
         display_start: usize,
         bytes: &[Option<u8>],
@@ -188,7 +191,11 @@ impl HexSession {
                     self.search.loose_focus();
                     self.jump_to.loose_focus();
 
-                    self.selection.update(addr);
+                    if shift_down {
+                        self.selection.shift_update(addr);
+                    } else {
+                        self.selection.update(addr);
+                    }
                 }
 
                 // Highlight byte if selected or modified
@@ -231,7 +238,11 @@ impl HexSession {
                     && let Some(hover) = pointer_hover
                     && label.rect.contains(hover)
                 {
-                    self.selection.update(addr);
+                    if shift_down {
+                        self.selection.shift_update(addr);
+                    } else {
+                        self.selection.update(addr);
+                    }
                 }
 
                 // Highlight char if selected or modified


### PR DESCRIPTION
When shift+click used, the range between selected bytes is marked as selected